### PR TITLE
Adding DB connection verification

### DIFF
--- a/util/db.js
+++ b/util/db.js
@@ -8,9 +8,14 @@ var server = new Server('localhost', 27017, {auto_reconnect: true});
 var db = new Db(confDB.name, server, { safe: true });
 
 db.open(function(err, db) {
-    console.log('Connecting to MongoDB: %s', db.databaseName);
-    if (err) {
-        console.trace(err);
+    if (db !== null) {
+        console.log('Connecting to MongoDB: %s', db.databaseName);
+        if (err) {
+            console.trace(err);
+            process.exit(1);
+        }
+    } else {
+        console.error('Could not connect to MongoDB Server. Is this thing on?');
         process.exit(1);
     }
 });


### PR DESCRIPTION
Currently, if the MongoDB server is down, the application will throw a TypeError, as the `db` var has no content. I've added a simple test to verify if it's healthy, giving better insights on database connection errors.
I'm not sure tho if there's a better way to output errors, as I'm new to Node, Express and stuff :)

From...
```
Listening on port 3000...
./keepfast/util/db.js:11
    console.log('Connecting to MongoDB: %s', db.databaseName);
                                               ^
TypeError: Cannot read property 'databaseName' of null
    at ./keepfast/util/db.js:11:48
```
To...
```
Listening on port 3000...
Could not connect to MongoDB Server. Is this thing on?
```